### PR TITLE
Feature/update yolo

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "plastic-origins"
-version = "2.2.2a0"
+version = "2.2.3"
 
 description = "A package containing methods commonly used to make inferences"
 repository = "https://github.com/surfriderfoundationeurope/surfnet"


### PR DESCRIPTION
Small fix to remove the hardcoded class names in yolo.py, using model.names instead.